### PR TITLE
ユーザーマイページ　本人情報確認画面　安井

### DIFF
--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -164,4 +164,116 @@
     }
   }
 
+  .identity_information_content {
+    float: right;
+    background: #fff;
+    width: 700px;
+    height: 1200px;
+    &__title {
+      font-size: 24px;
+      padding: 8px 24px;
+      font-weight: bold;
+      text-align: center;
+      border-bottom: 2px solid #f5f5f5;
+      color: #333;
+    }
+    .form_content {
+      padding: 64px;
+    }
+    p {
+      color: #333;
+      font-size: 14px;
+      margin: 8px 0 0;
+      line-height: 1.5;
+    }
+    .text_right {
+      color: #0199e8;
+      float: right;
+      text-decoration: none;
+      a:hover {
+        color: #72c2f1;
+        text-decoration: underline;
+      }
+      .icon-right {
+        font-size: 20px;
+        font-weight: bold;
+      }
+    }
+    .form_group {
+      clear: both;
+      padding: 30px 0 0;
+      &__label {
+        font-size: 14px;
+        font-weight: bold;
+        color: #333;
+      }
+      &__value {
+        font-size: 13px;
+      }
+      &__any {
+        background-color: #ccc;
+        margin: 0 0 0 8px;
+        padding: 2px 4px;
+        border-radius: 2px;
+        color: #fff;
+        font-size: 12px;
+        vertical-align: top;
+      }
+    }
+    .input-default {
+      width: 537px;
+      padding: 10px 16px 8px;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      background: #fff;
+      line-height: 1.5;
+      font-size: 16px;
+    }
+    .select-wrap{
+      position: relative;
+      &__icon-bottom{
+        position: absolute;
+        right: 0;
+        font-size: 28px;
+        font-weight: bold;
+        color: #888;
+        line-height: 44px;
+        padding-right: 16px;
+        }
+      }
+      .select-default{
+        position: relative;
+        z-index: 2;
+        height: 44px;
+        width: 572px;
+        padding: 0 16px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        background: 0;
+        font-size: 16px;
+        line-height: 1.5;
+        cursor: pointer;
+        -webkit-appearance:none;
+        -moz-appearance:none;
+        appearance:none;
+      }
+      .btn-red {
+        background: #ea352d;
+        border: 1px solid #ea352d;
+        color: #fff;
+      }
+      .btn-default {
+        margin: 40px 0 0 0;
+        display: block;
+        width: 100%;
+        line-height: 48px;
+        font-size: 14px;
+        border: 1px solid transparent;
+        -webkit-transition: all ease-out .3s;
+        transition: all ease-out .3s;
+        cursor: pointer;
+        text-align: center;
+        }
+      }
+
 }

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -2,4 +2,4 @@
   = render 'products/mypage/mypage-header'
   .margin
     = render 'products/mypage/side-bar'
-    = render 'products/mypage/logout'
+    = render 'products/mypage/identity-information'

--- a/app/views/products/mypage/_identity-information.html.haml
+++ b/app/views/products/mypage/_identity-information.html.haml
@@ -1,0 +1,98 @@
+.identity_information_content
+  .identity_information_content__title 本人情報の登録
+  %form.form_content{action: "#", method: "POST"}
+    %div
+      %p
+        お客さまの本人情報をご登録ください。
+        %br
+        登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+      %p.text_right
+        = link_to '#', class: 'text_right' do
+          本人確認書類のアップロードについて
+          = fa_icon 'angle-right', class:'icon-right'
+    .form_group
+      %label.form_group__label お名前
+      %p.form_group__value 安井 宏輔
+    .form_group
+      %label.form_group__label お名前カナ
+      %p.form_group__value ヤスイ コウスケ
+    .form_group
+      %label.form_group__label{for: "birthday"} 生年月日
+      %p.form_group__value 1989/02/16
+    .form_group
+      %label.form_group__label{for: "zip_code"} 郵便番号
+      %span.form_group__any 任意
+    %input.input-default{placeholder: "例）1234567"}/
+    .form_group
+      %label.form_group__label{for: "prefecture"} 都道府県
+      %span.form_group__any 任意
+      .select-wrap
+        = fa_icon 'angle-down', class:'select-wrap__icon-bottom'
+        %select.select-default
+          %option --
+          %option 北海道
+          %option 青森県
+          %option 岩手県
+          %option 宮城県
+          %option 秋田県
+          %option 山形県
+          %option 福島県
+          %option 東京都
+          %option 神奈川県
+          %option 埼玉県
+          %option 千葉県
+          %option 茨城県
+          %option 栃木県
+          %option 群馬県
+          %option 山梨県
+          %option 新潟県
+          %option 長野県
+          %option 富山県
+          %option 石川県
+          %option 福井県
+          %option 愛知県
+          %option 岐阜県
+          %option 静岡県
+          %option 三重県
+          %option 大阪府
+          %option 兵庫県
+          %option 京都府
+          %option 滋賀県
+          %option 奈良県
+          %option 和歌山県
+          %option 鳥取県
+          %option 島根県
+          %option 岡山県
+          %option 広島県
+          %option 山口県
+          %option 徳島県
+          %option 香川県
+          %option 愛媛県
+          %option 高知県
+          %option 福岡県
+          %option 佐賀県
+          %option 長崎県
+          %option 熊本県
+          %option 大分県
+          %option 宮崎県
+          %option 鹿児島県
+          %option 沖縄県
+    .form_group
+      %label.form_group__label{} 市区町村
+      %span.form_group__any 任意
+    %input.input-default{placeholder: "例) 横浜市緑区"}/
+    .form_group
+      %label.form_group__label{} 番地
+      %span.form_group__any 任意
+    %input.input-default{placeholder: "例) 青山1−1−1", type: "text"}/
+    .form_group
+      %label.form_group__label{} 建物名
+      %span.form_group__any 任意
+    %input.input-default{placeholder: "例) 柳ビル103"}/
+    %button.btn-default.btn-red{type: "submit"} 登録する
+    .form_group.text-right
+      %p
+        = link_to '#', class: 'text_right' do
+          本人情報の登録について
+          = fa_icon 'angle-right', class:'icon-right'
+    %input{type: "hidden"}/


### PR DESCRIPTION
#What
ユーザーマイページ内で使用する本人情報確認画面の部分テンプレートです。
編集ファイルは以下の通りです。

_mypage.scss
本人情報確認画面に使用するcssを追加しました。

_identity-information.html.haml
本人情報確認画面に使用する部分テンプレートファイルです。
この中にコードを記述しました。

index.html.haml
ローカル確認のために変更しました。