### PR TITLE
ユーザークレジットカード登録ページ　あるとき/ないとき　安井

### DIFF
--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -276,4 +276,130 @@
         }
       }
 
+  .creditcard_content {
+    float: right;
+    background: #fff;
+    width: 700px;
+    height: 364px;
+    &__title {
+      font-size: 24px;
+      padding: 8px 24px;
+      font-weight: bold;
+      text-align: center;
+      border-bottom: 2px solid #f5f5f5;
+      color: #333;
+    }
+    .creditcard_list_content {
+      padding: 64px;
+      &__title {
+      max-width: 320px;
+      margin: 0 auto;
+      &--text {
+        font-weight: bold;
+      }
+    }
+    &__border-bottom {
+      height: 100%;
+      padding-bottom:  20px;
+      border-bottom: 1px solid #eee;
+    }
+  }
+  .creditcard_list {
+    height: 64px; 
+    width: 320px;
+    margin: 0 auto;
+    position: relative;
+    padding: 24px 0px 0px 0px;
+    &__num {
+      font-size: 14px;
+    }
+  }
+  .creditcard_introduction {
+      float: right;
+      margin: 40px 10px;
+      font-size: 14px;
+      .text-color {
+        text-decoration: none;
+        color: #0199e8;
+      }
+      a:hover {
+        color: #72c2f1;
+        text-decoration: underline;
+      }
+      .icon-right {
+        font-size: 20px;
+        font-weight: bold;
+      }
+    }
+    .settings-payment-remove {
+      position: absolute;
+      top: 30px;
+      right: 0;
+      padding: 4px 6px;
+      background: #fff;
+      border-radius: 3px;
+      border: 1px solid #ea352d;
+      color: #ea352d;
+    }
+  }
+
+  .creditcard_less_content {
+      float: right;
+      width: 700px;
+      height: 358px;
+      background: #fff;
+      .title {
+        font-size: 24px;
+        padding: 8px 24px;
+        font-weight: bold;
+        text-align: center;
+        border-bottom: 2px solid #f5f5f5;
+        color: #333;
+      }
+      .menu {
+        width: 572px;
+        border-bottom: 1px solid #eee;
+        margin: 64px 64px 40px 64px;
+        &__title {
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0px 126px;
+        }
+        &__btn {
+          height: 48px;
+          width: 318px;
+          margin: 24px 126px;
+          background: #ea352d;
+          border: 1px solid #ea352d;
+          color: #fff;
+          text-align: center;
+          line-height: 48px;
+          font-size: 14px;
+          .icon-card {
+            margin-right: 16px;
+            font-weight: bold;
+          }
+        }
+      }
+      .creditcard_introduction {
+        float: right;
+        margin: 40px 10px;
+        font-size: 14px;
+        .text-color{
+          text-decoration: none;
+          color: #0199e8;
+        }
+        a:hover {
+          color: #72c2f1;
+          text-decoration: underline;
+        }
+        .icon-right {
+          font-size: 20px;
+          font-weight: bold;
+        }
+      }
+      .btu-color {
+        text-decoration: none;
+      }
+    }
 }

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -2,4 +2,4 @@
   = render 'products/mypage/mypage-header'
   .margin
     = render 'products/mypage/side-bar'
-    = render 'products/mypage/identity-information'
+    = render 'products/mypage/creditcard-less'

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -2,4 +2,4 @@
   = render 'products/mypage/mypage-header'
   .margin
     = render 'products/mypage/side-bar'
-    = render 'products/mypage/creditcard-less'
+    = render 'products/mypage/creditcard'

--- a/app/views/products/mypage/_creditcard-less.html.haml
+++ b/app/views/products/mypage/_creditcard-less.html.haml
@@ -1,0 +1,13 @@
+.creditcard_less_content
+  .title 支払い方法
+  .menu
+    .creditcard_menu
+      .menu__title クレジットカード一覧
+      = link_to "#" , class:"btu-color" do
+        .menu__btn
+          = fa_icon 'credit-card', class:'icon-card'
+          クレジットカードを追加する
+    .creditcard_introduction
+      = link_to "#", class:"text-color" do
+        支払い方法について
+        = fa_icon 'angle-right', class:'icon-right'

--- a/app/views/products/mypage/_creditcard.html.haml
+++ b/app/views/products/mypage/_creditcard.html.haml
@@ -5,7 +5,7 @@
       .creditcard_list_content__title
         .creditcard_list_content__title--text クレジットカード一覧
       .creditcard_list
-        %img{alt: "visa", height: "15", src: "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3856598694", width: "49"}/
+        = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3856598694", size: "49x15", alt: "visa"
         .creditcard_list__num ************0000
         .creditcard_list__num 00 / 00
         %button.settings-payment-remove{type: "submit"}

--- a/app/views/products/mypage/_creditcard.html.haml
+++ b/app/views/products/mypage/_creditcard.html.haml
@@ -1,0 +1,16 @@
+.creditcard_content
+  .creditcard_content__title 支払い方法
+  .creditcard_list_content
+    .creditcard_list_content__border-bottom
+      .creditcard_list_content__title
+        .creditcard_list_content__title--text クレジットカード一覧
+      .creditcard_list
+        %img{alt: "visa", height: "15", src: "//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?3856598694", width: "49"}/
+        .creditcard_list__num ************0000
+        .creditcard_list__num 00 / 00
+        %button.settings-payment-remove{type: "submit"}
+          削除する
+    .creditcard_introduction
+      = link_to "#", class:"text-color" do
+        支払い方法について
+        = fa_icon 'angle-right', class:'icon-right'


### PR DESCRIPTION
#What
ユーザーマイページ内で使用するクレジットカード登録ページの部分テンプレートです。
編集ファイルは以下の通りです。

#CSS
_mypage.scss
クレジットカード登録ページに使用するcssを追加しました。

.creditcard_content {
ここの記述が登録されている時に使用するページのcssです。
}

.creditcard_less_content {
ここの記述が登録されていない時に使用するページのcssです。
}

#HTML
__creditcard.html.haml
ここが登録されている時に使用する部分テンプレートファイルです。
CSSの「.creditcard_content」が当たります。

_creditcard-less.html.haml
ここが登録されていない時に使用する部分テンプレートファイルです。
CSSの「.creditcard_less_content」が当たります。

index.html.haml
ローカル確認のために変更しました。

#あるとき
<img width="1344" alt="スクリーンショット 2019-06-01 19 24 02" src="https://user-images.githubusercontent.com/50067058/58747233-4a253980-84a3-11e9-85c2-d21fe5301d9b.png">

#ないとき
<img width="1344" alt="スクリーンショット 2019-06-01 19 24 30" src="https://user-images.githubusercontent.com/50067058/58747235-4db8c080-84a3-11e9-8cb8-19c85f14d922.png">