### PR TITLE
ルート作成後のビュー崩れ　修正　安井

### DIFF
--- a/app/views/products/mypage/_logout.html.haml
+++ b/app/views/products/mypage/_logout.html.haml
@@ -1,2 +1,2 @@
 .logout_content
-  = link_to 'ログアウト', '/users/sign_out', class: 'logout_content__logout_btn', method: :delete,
+  = link_to 'ログアウト', '/users/sign_out', class: 'logout_content__logout_btn'


### PR DESCRIPTION
問題点
①本人情報の登録のビューが乱れていた
②ログアウトボタンが消えていた

①. 向川さんのcssが原因（wrapper）修正依頼

②.
 = link_to 'ログアウト', '/users/sign_out', class: 'logout_content__logout_btn', method: :delete,
↓
 = link_to 'ログアウト', '/users/sign_out', class: 'logout_content__logout_btn'
