### PR TITLE
商品詳細ページ修正(パンくず追加)

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,5 @@
 = render 'products/top-page/toppage-header'
 .wrapper
-  = render 'products/mypage/mypage-header'
+  = render 'products/mypage/mypage-header/index-header'
 = render 'products/items/details'
 = render 'products/top-page/toppage-footer'


### PR DESCRIPTION
## WHAT
商品詳細ページにパンくずが追加できていなかったので追加した。

## WHY
必須実装のため。