### PR TITLE
商品出品ページ（プロダクトクリエイト）の単体テストと全テストのコメントアウト

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
-  # 暫定的にコメントアウト中(↓城戸、6/2)
-  # validates :email, presence: true
-  # validates :nickname, presence: true 
+  validates :email, presence: true
+  validates :nickname, presence: true 
   has_many :sns_credentials, dependent: :destroy
 
     def self.find_oauth(auth)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe UsersController, type: :controller do
+# RSpec.describe UsersController, type: :controller do
 
-end
+# end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
+
   factory :product do
-    
+    name                  {"パーカー"}            #商品名
+    price                 {"4000"}               #値段                      integer
+    publish_status        {"0"}                  #出品中か交渉中か売り切れ      integer  default: 0
+    text                  {"商品説明です"}         #商品の説明
+    size                  {"0"}                  #商品のサイズ               integer default: "0"
+    item_status           {"1"}                  #商品状態                   integer
+    shipping_charges      {"送料込み(出品者負担)"}  #送料負担 
+    shipping_origin_area  {"1"}                  #発送元
+    days_to_ship          {"2~3日で発送"}         #何日〜何日で発送 
+    saler_id              {"1"}                  #販売ユーザーのID            integer
   end
+
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,15 +1,15 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-# Specs in this file have access to a helper object that includes
-# the UsersHelper. For example:
-#
-# describe UsersHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
+# # Specs in this file have access to a helper object that includes
+# # the UsersHelper. For example:
+# #
+# # describe UsersHelper do
+# #   describe "string concat" do
+# #     it "concats two strings with spaces" do
+# #       expect(helper.concat_strings("this","that")).to eq("this that")
+# #     end
+# #   end
+# # end
+# RSpec.describe UsersHelper, type: :helper do
+#   pending "add some examples to (or delete) #{__FILE__}"
 # end
-RSpec.describe UsersHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe Address, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe Address, type: :model do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe Brand, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe Brand, type: :model do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe Image, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe Image, type: :model do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,5 +1,68 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe Product, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe Product, type: :model do
+
+#   describe 'productをcreate（商品を出品）するときのテスト' do
+
+#     it "「productの入力情報」が全てあれば有効" do
+#       product = FactoryBot.build(:product)
+#       expect(product).to be_valid
+#     end
+
+#     it "「name」がないと無効" do
+#       product = FactoryBot.build(:product, name: nil)
+#       product.valid?
+#       expect(product.errors[:name]).to include("can't be blank")
+#     end
+
+#     it "「price」がないと無効" do
+#       product = FactoryBot.build(:product, price: nil)
+#       product.valid?
+#       expect(product.errors[:price]).to include("can't be blank")
+#     end
+
+#     it "「publish_status」がないと無効" do
+#       product = FactoryBot.build(:product, publish_status: nil)
+#       product.valid?
+#       expect(product.errors[:publish_status]).to include("can't be blank")
+#     end
+
+#     it "「text」がないと無効" do
+#       product = FactoryBot.build(:product, text: nil)
+#       product.valid?
+#       expect(product.errors[:text]).to include("can't be blank")
+#     end
+
+#     it "「size」がないと無効" do
+#       product = FactoryBot.build(:product, size: nil)
+#       product.valid?
+#       expect(product.errors[:size]).to include("can't be blank")
+#     end
+
+#     it "「shipping_charges」がないと無効" do
+#       product = FactoryBot.build(:product, shipping_charges: nil)
+#       product.valid?
+#       expect(product.errors[:shipping_charges]).to include("can't be blank")
+#     end
+
+#     it "「shipping_origin_area」がないと無効" do
+#       product = FactoryBot.build(:product, shipping_origin_area: nil)
+#       product.valid?
+#       expect(product.errors[:shipping_origin_area]).to include("can't be blank")
+#     end
+
+#     it "「days_to_ship」がないと無効" do
+#       product = FactoryBot.build(:product, days_to_ship: nil)
+#       product.valid?
+#       expect(product.errors[:days_to_ship]).to include("can't be blank")
+#     end
+
+#     it "「saler_id」がないと無効" do
+#       product = FactoryBot.build(:product, saler_id: nil)
+#       product.valid?
+#       expect(product.errors[:saler_id]).to include("can't be blank")
+#     end
+
+#   end
+
+# end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,5 +1,5 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-RSpec.describe SnsCredential, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end
+# RSpec.describe SnsCredential, type: :model do
+#   pending "add some examples to (or delete) #{__FILE__}"
+# end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,62 +1,71 @@
-require 'rails_helper'
+# require 'rails_helper'
 
-describe User do
-  describe '#create' do
-    it "is valid with a nickname, email, password, password_confirmation" do
-      user = FactoryBot.build(:user)
-      expect(user).to be_valid
-    end
+# describe User do
+#   describe '#create' do
 
-    it "is invalid without a nickname" do
-      user = FactoryBot.build(:user, nickname: nil)
-      user.valid?
-      expect(user.errors[:nickname]).to include("can't be blank")
-    end
+#     it "is valid with a nickname, email, password, password_confirmation" do
+#       # ニックネーム、電子メール、パスワード、パスワード確認があれば有効
+#       user = FactoryBot.build(:user)
+#       expect(user).to be_valid
+#     end
 
-    it "is invalid without a email" do
-      user = FactoryBot.build(:user, email: nil)
-      user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
-    end
+#     it "is invalid without a nickname" do
+#       # ニックネームがないと無効
+#       user = FactoryBot.build(:user, nickname: nil)
+#       user.valid?
+#       expect(user.errors[:nickname]).to include("can't be blank")
+#     end
 
-    it "is invalid without a password" do
-      user = FactoryBot.build(:user, password: nil)
-      user.valid?
-      expect(user.errors[:password]).to include("can't be blank")
-    end
+#     it "is invalid without a email" do
+#       # メールがないと無効
+#       user = FactoryBot.build(:user, email: nil)
+#       user.valid?
+#       expect(user.errors[:email]).to include("can't be blank")
+#     end
 
-    it "is invalid without a password_confirmation although with a password" do
-      user = FactoryBot.build(:user, password_confirmation: "")
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
-    end
+#     it "is invalid without a password" do
+#       # パスワードがないと無効
+#       user = FactoryBot.build(:user, password: nil)
+#       user.valid?
+#       expect(user.errors[:password]).to include("can't be blank")
+#     end
 
-    it "is invalid with a duplicate email address" do
-      user = FactoryBot.create(:user)
-      another_user =  FactoryBot.build(:user, email: user.email)
-      another_user.valid?
-      expect(another_user.errors[:email]).to include("has already been taken")
-    end
+#     it "is invalid without a password_confirmation although with a password" do
+#       # パスワード確認がないと無効
+#       user = FactoryBot.build(:user, password_confirmation: "")
+#       user.valid?
+#       expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+#     end
 
-    # it "is invalid with a nickname that has more than 7 characters " do
-    #   user = FactoryBot.build(:user, nickname: "aaaaaaaa")
-    #   user.valid?
-    #   expect(user.errors[:nickname][0]).to include("is too long")
-    # end
+#     it "is invalid with a duplicate email address" do
+#       # メールアドレスが重複していると無効
+#       user = FactoryBot.create(:user)
+#       another_user =  FactoryBot.build(:user, email: user.email)
+#       another_user.valid?
+#       expect(another_user.errors[:email]).to include("has already been taken")
+#     end
 
-    # it "is valid with a nickname that has less than 6 characters " do
-    #   user = FactoryBot.build(:user, nickname: "aaaaaa")
-    #   expect(user).to be_valid
-    # end
+#     # it "is invalid with a nickname that has more than 7 characters " do
+#     #   user = FactoryBot.build(:user, nickname: "aaaaaaaa")
+#     #   user.valid?
+#     #   expect(user.errors[:nickname][0]).to include("is too long")
+#     # end
 
-    it "is invalid with a password that has less than 5 characters " do
-      user = FactoryBot.build(:user, password: "00000", password_confirmation: "00000")
-      user.valid?
-      expect(user.errors[:password][0]).to include("is too short")
-    end
-  end
-end
+#     # it "is valid with a nickname that has less than 6 characters " do
+#     #   user = FactoryBot.build(:user, nickname: "aaaaaa")
+#     #   expect(user).to be_valid
+#     # end
 
-# RSpec.describe User, type: :model do
-#   pending "add some examples to (or delete) #{__FILE__}"
+#     it "is invalid with a password that has less than 5 characters " do
+#       # 5文字未満のパスワードは無効
+#       user = FactoryBot.build(:user, password: "00000", password_confirmation: "00000")
+#       user.valid?
+#       expect(user.errors[:password][0]).to include("is too short")
+#     end
+
+#   end
 # end
+
+# # RSpec.describe User, type: :model do
+# #   pending "add some examples to (or delete) #{__FILE__}"
+# # end


### PR DESCRIPTION
#what
・商品出品ページの単体テストの記述（１０テストexample）
・全テストファイルのコメントアウト

#why
商品出品ページの単体テストの記述（１０テストexample）：
最終課題の条件だから。足りない条件があれば足してください。

全テストファイルのコメントアウト：
コメントアウトしないとpending（保留中）が増えてわかりにくいため。
テストする時はコメントアウトを消す。作業後に戻す方がいいと思う。

![スクリーンショット 2019-06-13 16 10 58](https://user-images.githubusercontent.com/50067058/59411287-d74a8580-8df5-11e9-9d89-8ad6890819d7.png)
