### PR TITLE
FB/Google連携　微修正

### DIFF
--- a/app/assets/stylesheets/_items.scss
+++ b/app/assets/stylesheets/_items.scss
@@ -972,3 +972,11 @@ li {
 .item-box__body {
   width: 213px;
 }
+
+.facebook-btn {
+  color: white
+}
+
+.google-btn {
+  color: black
+}

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,7 +21,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
     else 
       session["devise.sns_id"] = sns_id 
-      render template: "users/registrations/new" 
+      # before
+      # render template: "users/registrations/new" 
+      render "registers/memberinfo"
     end
   end
 

--- a/app/views/products/member-registration/_registration-main-contents.html.haml
+++ b/app/views/products/member-registration/_registration-main-contents.html.haml
@@ -7,12 +7,15 @@
           = link_to memberinfo_registers_path, class: 'btn-default btn-mail' do
             = fa_icon "envelope", class: "icon-mail"
             メールアドレスで登録
+            
           %button#facebook-login.btn-default.btn-sns.btn-sns-facebook
+            = link_to "Facebookで登録",user_facebook_omniauth_authorize_path,  class: 'facebook-btn'
             = fa_icon "facebook-square", class: "icon-sns"
-            Facebookで登録
+
           %button#google-login.btn-default.btn-sns.btn-sns-google
+            = link_to "Googleで登録",user_google_oauth2_omniauth_authorize_path,  class: 'google-btn'
             = image_tag "google.png" ,  height:25 , class: "icon-sns"
-            Googleで登録
+
     %form#login_form_facebook{action: "/jp/signup/facebook/", method: "POST", novalidate: "novalidate"}
       %input{name: "__csrf_value", type: "hidden", value: "49797f1edd453785d17eb5a55fe5422b5e627796081122f82ba85bd3526dded666f73ab52a625534f629d0b36498dace9e72a8b05374f8cdc1d84fcd5840fc8cf"}/
       %input{name: "nickname", type: "hidden", value: ""}/


### PR DESCRIPTION
##WHAT

FB, Googleログインにつき、山西さんに機能指摘された点を修正。
①僕らが作った『Facebookで新規登録』『Googleで新規登録』ボタンから新規登録が出来る
②Facebook/Googleの名前/e-mailアドレスが、(僕らが作成したビューに反映される)
[
![ログイン機能修正 mov](https://user-images.githubusercontent.com/50075642/59547070-8fea0380-8f73-11e9-9883-0c4457901ae1.gif)
](url)