### PR TITLE
【サーバーサイド】ユーザー新規登録の際に５ページに移動できない

### DIFF
--- a/app/assets/stylesheets/_registration.scss
+++ b/app/assets/stylesheets/_registration.scss
@@ -243,6 +243,7 @@
   .info-content {
     background: #fff;
     width: 700px;
+    height: 100%;
     margin: 0 auto;
     &__head {
       padding: 24px 8px;
@@ -408,7 +409,7 @@
       }
     }
     .btn-red {
-      margin: 40px 0 0;
+      margin: 40px 0;
       background: #ea352d;
       border: 1px solid #ea352d;
       color: #fff;

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -1,18 +1,18 @@
 class RegistersController < ApplicationController
- 
- def memberinfo
- end
 
- def numberverification
- end
+  def memberinfo
+  end
 
- def memberaddfress
- end
- 
- def payment
- end
+  def numberverification
+  end
 
- def completion
- end
+  def memberaddfress
+  end
+
+  def payment
+  end
+
+  def completion
+  end
 
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,20 +1,26 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+
   def create
-    #binding.pry
      if params[:user][:password] == "" #sns登録なら
        params[:user][:password] = "Devise.friendly_token.first(6)" #deviseのパスワード自動生成機能を使用
        params[:user][:password_confirmation] = "Devise.friendly_token.first(6)"
        super
-       # binding.pry
        sns = SnsCredential.update(user_id:  @user.id)
      else #email登録なら
-      redirect_to numberverification_registers_path and return
-       # binding.pry
        super
+       after_sign_up_path_for(resource)
      end
+     
    end
+
+   protected
+ 
+   def after_sign_up_path_for(resource)
+    numberverification_registers_path
+   end
+
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,6 +10,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
        # binding.pry
        sns = SnsCredential.update(user_id:  @user.id)
      else #email登録なら
+      redirect_to numberverification_registers_path and return
        # binding.pry
        super
      end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/views/products/member-detail/_member-adress.html.haml
+++ b/app/views/products/member-detail/_member-adress.html.haml
@@ -103,4 +103,22 @@
         .main-content
           = link_to payment_registers_path, class: "kasen" do
             %button.btn-default.btn-red{type: "submit"} 次へ進む
+  
  
+    -#  = form_with(model: Address.new, method: :post, url: registers_path, local: true) do |f| 
+    -#   郵便番号
+    -#   = f.text_field        :postal_code
+ 
+    -#   都道府県
+    -#   = f.collection_select :prefecture,  Prefecture.all, :id, :name
+
+    -#   市区町村
+    -#   = f.text_field        :city
+
+    -#   番地
+    -#   = f.text_field        :address
+
+    -#   建物名
+    -#   = f.text_field        :building
+
+    -#   = f.submit "変更する", class:"btn-default btn-red"  

--- a/app/views/products/member-detail/_member-info.html.haml
+++ b/app/views/products/member-detail/_member-info.html.haml
@@ -85,10 +85,7 @@
               %a{:href => "/jp/tos_list/", :target => "_blank"}> 利用規約
               に同意したものとみなします
           .actions
-            = f.submit "新規登録(仮)", class: "btn-red"   
-          .actions
-          = link_to numberverification_registers_path, class:"login-link" do
-            次の画面へ
+            = f.submit "新規登録", class: "btn-red"   
 
 
           -# .form-group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
 
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks', registrations: 'users/registrations' }
+  devise_for :users, controllers: { 
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    registrations: 'users/registrations' }
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
@@ -11,6 +13,13 @@ Rails.application.routes.draw do
       get 'purchasing'
     end
   end
+
+  devise_scope :user do
+    constraint = lambda do |request|
+      request.env["devise.mapping"] = Devise.mappings[scope]
+      true
+  end
+end
 
   resources :users do
 


### PR DESCRIPTION
新規登録（メアド登録）後に１ページ目の新規登録を行うと次に行かずにトップページに飛んでしまう問題を解決しました。

https://gyazo.com/fe912d6205d0a547318cfde36b783fd8