### PR TITLE
新規登録時の住所登録

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -7,12 +7,24 @@ class RegistersController < ApplicationController
  end
 
  def memberaddfress
- end
  
+ end
+
+ def create
+  Address.create(address_params)
+  redirect_to payment_registers_path
+ end
+
+
  def payment
  end
 
  def completion
  end
+
+  private
+  def address_params
+    params.require(:address).permit(:postal_code, :prefecture, :city, :address,:building).merge(user_id: current_user.id)
+  end
 
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,7 +1,7 @@
 class Address < ApplicationRecord
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :prefecture
+  # belongs_to_active_hash :prefecture
 
   validates :postal_code,  presence: true
   validates :prefecture,   presence: true

--- a/app/views/products/member-detail/_member-adress.html.haml
+++ b/app/views/products/member-detail/_member-adress.html.haml
@@ -24,83 +24,33 @@
   .info-main
     .info-content
       %h2.info-content__head 住所入力
-      %form.info-inner.registration-form{action: "https://www.mercari.com/jp/signup/sms_confirmation/?after_save_callbacttps://www.mercari.com/jp/", method: "POST", novalidate: "novalidate"}
+      = form_with(model: Address.new, method: :post, url: registers_path, local: true, class: "info-inner registration-form") do |f| 
         %input{name: "__csrf_value", type: "hidden",value: ""}/
         .main-content
           .form-group
             %label{for: "postal_code"} 郵便番号
             %span.form-require 必須
-            %input.input-default{name: "postal_code", placeholder: "例) 123-4567", type: "integer",value: ""}/
+            = f.text_field        :postal_code, class:'input-default', placeholder:  "例) 123-4567"
           .form-group
             %label{for: "prefecture"} 都道府県
             %span.form-require 必須
             %br/
             .birthday-select-wrap
               .select-wrap
-                %select.select-default{name: "prefecture"}
-                  %option{value: ""} --
-                  %option{value: "北海道"} 北海道
-                  %option{value: "青森県"} 青森県
-                  %option{value: "岩手県"} 岩手県
-                  %option{value: "宮城県"} 宮城県
-                  %option{value: "秋田県"} 秋田県
-                  %option{value: "山形県"} 山形県
-                  %option{value: "福島県"} 福島県
-                  %option{value: "茨城県"} 茨城県
-                  %option{value: "栃木県"} 栃木県
-                  %option{value: "群馬県"} 群馬県
-                  %option{value: "埼玉県"} 埼玉県
-                  %option{value: "千葉県"} 千葉県
-                  %option{value: "東京都"} 東京都
-                  %option{value: "神奈川県"} 神奈川県
-                  %option{value: "新潟県"} 新潟県
-                  %option{value: "富山県"} 富山県
-                  %option{value: "石川県"} 石川県
-                  %option{value: "福井県"} 福井県
-                  %option{value: "山梨県"} 山梨県
-                  %option{value: "長野県"} 長野県
-                  %option{value: "岐阜県"} 岐阜県
-                  %option{value: "静岡県"} 静岡県
-                  %option{value: "愛知県"} 愛知県
-                  %option{value: "三重県"} 三重県
-                  %option{value: "滋賀県"} 滋賀県
-                  %option{value: "京都府"} 京都府
-                  %option{value: "大阪府"} 大阪府
-                  %option{value: "兵庫県"} 兵庫県
-                  %option{value: "奈良県"} 奈良県
-                  %option{value: "和歌山県"} 和歌山県
-                  %option{value: "鳥取県"} 鳥取県
-                  %option{value: "島根県"} 島根県
-                  %option{value: "岡山県"} 岡山県
-                  %option{value: "広島県"} 広島県
-                  %option{value: "山口県"} 山口県
-                  %option{value: "徳島県"} 徳島県
-                  %option{value: "香川県"} 香川県
-                  %option{value: "愛媛県"} 愛媛県
-                  %option{value: "高知県"} 高知県
-                  %option{value: "福岡県"} 福岡県
-                  %option{value: "佐賀県"} 佐賀県
-                  %option{value: "長崎県"} 長崎県
-                  %option{value: "熊本県"} 熊本県
-                  %option{value: "大分県"} 大分県
-                  %option{value: "宮崎県"} 宮崎県
-                  %option{value: "鹿児島県"} 鹿児島県
-                  %option{value: "沖縄県"} 沖縄県
+                = f.collection_select :prefecture,  Prefecture.all, :id, :name,{prompt: "---"},{class:"select-default"} 
                 = fa_icon 'angle-down', class: 'angle-down'
             %input{name: "prefecture", type: "hidden",value: ""}/
           .form-group
             %label{for: "city"} 市区町村
             %span.form-require 必須
-            %input.input-default{name: "city", placeholder: "例) 横浜市緑区", type: "string",value: ""}/
+            = f.text_field        :city, class: 'input-default',placeholder: "例) 横浜市緑区"
           .form-group
             %label{for: "address"} 番地
             %span.form-require 必須
-            %input.input-default{name: "address", placeholder: "例) 青山1-1-1", type: "string",value: ""}/
+            = f.text_field        :address, class:'input-default', placeholder: "例) 青山1-1-1"
           .form-group
             %label{for: "building"} 建物名
             %span.form-optional  任意
-            %input.input-default{name: "building", placeholder: "例) なんとかビル103", type: "string",value: ""}/
+            = f.text_field        :building, class:'input-default',  placeholder: "例) なんとかビル103"
         .main-content
-          = link_to payment_registers_path, class: "kasen" do
-            %button.btn-default.btn-red{type: "submit"} 次へ進む
- 
+          = f.submit "次へ進む", class:"btn-default btn-red"  


### PR DESCRIPTION
## WHAT

会員登録ページから、住所の登録が出来るようになりました。

(詳細)addessモデル"belongs_to_active_hash :prefecture"記載を削除すれば、住所の登録が出来るようになりました。
ビューへの"○○県"という名前の呼び出しも、下記画面の通りにやれば可能かと思われます。

[
<img width="969" alt="スクリーンショット 2019-06-16 10 21 39" src="https://user-images.githubusercontent.com/50075642/59558116-98027b80-9025-11e9-905e-b89068498d94.png">
](url)

[
![住所登録2nd mov](https://user-images.githubusercontent.com/50075642/59558117-a18be380-9025-11e9-9445-604957d2229a.gif)
](url)

