### PR TITLE
商品購入ページでユーザーの情報と商品の情報を表示できようにした

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,7 +34,6 @@ class ProductsController < ApplicationController
     @saler = User.find(id= @product.saler_id)
     @prefecture = Prefecture.find(@product.shipping_origin_area_was)
     @item_status = ItemStatus.find(@product.item_status_was)
-
   end
   
   def new

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -4,6 +4,11 @@ class PurchasesController < ApplicationController
 
   def index
     @product=Product.find(params[:id])
+
+    @user = User.find(id= current_user.id)
+    @address = @user.address
+    @prefecture = Prefecture.find(@address.prefecture_was)
+
     card = Card.where(user_id: current_user.id).first
     if card.blank?
       redirect_to controller: "card", action: "new"

--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,2 +1,7 @@
 module PurchasesHelper
+
+  def address_to_jpy(address)
+    "#{address.to_s(:phone)}"
+  end
+
 end

--- a/app/views/purchases/index.html.haml
+++ b/app/views/purchases/index.html.haml
@@ -1,4 +1,5 @@
 = render 'products/member-registration/header'
+
 .purchasing-top
   %header.single--header
   .single-main__container
@@ -7,7 +8,8 @@
       .purchase-content__inner
         %h3.purchase-content__inner--image
           = image_tag @product.images.first , class: "photo", height: "148", width: "112"
-        %p.purchase-content__inner--name ２つ折り財布
+        %p.purchase-content__inner--name
+          = @product.name
         .buy-form
           %p.purchase-content__inner--price 
             ¥
@@ -29,12 +31,15 @@
       .userinfo-content__inner
         %h3 配送先
         %address.userinfo-content__inner--text
-          〒556-0026
+          〒
+          = address_to_jpy(@address.postal_code)
           %br/
-          大阪府 大阪市浪速区浪速西
-          2-12-16
+          = @prefecture.name
+          = @address.city
+          = @address.address
           %br/
-          城戸 隆文
+          = @user.family_name
+          = @user.first_name
         %a.userinfo-content__inner--userinfofix{href: "/"}
           .userinfo-content--btn
             = link_to '#' do


### PR DESCRIPTION
<img width="486" alt="スクリーンショット 2019-06-19 13 00 17" src="https://user-images.githubusercontent.com/50067058/59735833-33982400-9292-11e9-8dd4-b6e3d43ed357.png">

商品名　= @product.name
区切った値段　= converting_to_jpy(@product.price)
区切った郵便番号　= address_to_jpy(@address.postal_code)
userの都道府県　= @prefecture.name
userの住所　= @address.city
userの番地　= @address.address
userの苗字　= @user.family_name
userの名前　= @user.first_name
