### PR TITLE
Update _details.html.haml

### DIFF
--- a/app/views/products/items/_details.html.haml
+++ b/app/views/products/items/_details.html.haml
@@ -73,8 +73,12 @@
       .item-detail-confirmation-price_box-shipping
         送料込み
 
-    - if @product.buyer_id == 0
+    - if @product.buyer_id == 0 && user_signed_in?
       = link_to purchase_path do
+        .item-detail-confirmation-buy_btn
+          購入画面に進む
+    - elsif @product.buyer_id == 0
+      = link_to login_users_path do
         .item-detail-confirmation-buy_btn
           購入画面に進む
     - else


### PR DESCRIPTION
## WHAT
未ログイン時、商品詳細ページの購入画面に進むを押した時にエラーメッセージではなく、ログイン画面に遷移するようにする。

## WHY
現在の仕様では、未ログイン時、商品詳細ページの購入画面に進むを押した時にエラーメッセージが
表示されるため。

https://gyazo.com/8b2abeb838d22d90642d803dab1a6996