### PR TITLE
出品者のみ削除可能commit

### DIFF
--- a/app/views/products/items/_details.html.haml
+++ b/app/views/products/items/_details.html.haml
@@ -126,9 +126,10 @@
       %li.pinterest
         = link_to '#' do
           = fa_icon "fas", class: "fa-pinterest-square"
-    %p.delete-btn
-      = link_to  product_path(@product), class: "gray-delete", method: :delete do
-        この商品を削除する
+    -if user_signed_in? && @product.saler_id == current_user.id
+      %p.delete-btn
+        = link_to  product_path(@product), class: "gray-delete", method: :delete do
+          この商品を削除する
       
   %h2
     = link_to '#' do


### PR DESCRIPTION
#WHAT
出品したユーザーのみ削除ボタンが表示されるように修正。

未ログイン時は削除ボタン非表示。
ログインしていても出品したユーザーでなければ削除ボタン非表示。

挙動動画
1.未ログインの場合
https://i.gyazo.com/ea7bc53cd56a7fab10a4c71a93886ea2.gif
2.ログイン且つ出品ユーザーでない場合
https://i.gyazo.com/d2909146d39a83db895748026545ae51.gif
3.ログイン且つ出品ユーザーの場合
https://i.gyazo.com/844f34498899191d942c06503cadcf9c.gif