### PR TITLE
自分が出品した商品は購入できないようにする

### DIFF
--- a/app/views/products/items/_details.html.haml
+++ b/app/views/products/items/_details.html.haml
@@ -73,7 +73,9 @@
       .item-detail-confirmation-price_box-shipping
         送料込み
 
-    - if @product.buyer_id == 0 && user_signed_in?
+    - if @product.buyer_id == 0 && user_signed_in? && current_user.id == @product.saler_id
+      .item-detail-confirmation-self_product-can_not_buy
+    - elsif @product.buyer_id == 0 && user_signed_in?
       = link_to purchase_path do
         .item-detail-confirmation-buy_btn
           購入画面に進む


### PR DESCRIPTION
## WHAT
自分が出品した商品は購入できないようにした。
具体的には、商品詳細ページで自分の出品した商品に関しては、「購入画面に進む」ボタンを表示しないようにした。

https://gyazo.com/ad60f3d2ac88168f96bf93cfad06c347