### PR TITLE
ユーザー情報(住所)必須入力commit

### DIFF
--- a/app/views/products/member-detail/_member-adress.html.haml
+++ b/app/views/products/member-detail/_member-adress.html.haml
@@ -30,24 +30,24 @@
           .form-group
             %label{for: "postal_code"} 郵便番号
             %span.form-require 必須
-            = f.text_field        :postal_code, class:'input-default', placeholder:  "例) 123-4567"
+            = f.text_field        :postal_code, class:'input-default', placeholder:  "例) 123-4567",required:"required"
           .form-group
             %label{for: "prefecture"} 都道府県
             %span.form-require 必須
             %br/
             .birthday-select-wrap
               .select-wrap
-                = f.collection_select :prefecture,  Prefecture.all, :id, :name,{prompt: "---"},{class:"select-default"} 
+                = f.collection_select :prefecture,  Prefecture.all, :id, :name,{prompt: "---"},class:"select-default", required:"required"
                 = fa_icon 'angle-down', class: 'angle-down'
             %input{name: "prefecture", type: "hidden",value: ""}/
           .form-group
             %label{for: "city"} 市区町村
             %span.form-require 必須
-            = f.text_field        :city, class: 'input-default',placeholder: "例) 横浜市緑区"
+            = f.text_field        :city, class: 'input-default',placeholder: "例) 横浜市緑区",required:"required"
           .form-group
             %label{for: "address"} 番地
             %span.form-require 必須
-            = f.text_field        :address, class:'input-default', placeholder: "例) 青山1-1-1"
+            = f.text_field        :address, class:'input-default', placeholder: "例) 青山1-1-1",required:"required"
           .form-group
             %label{for: "building"} 建物名
             %span.form-optional  任意


### PR DESCRIPTION
# WHAT
住所入力formにrequiredをつけた

# WHY
商品購入完了ページで購入者の配送先住所情報を表示させるために
purchase controllerでadressの変数を定義していたが、
新規登録の際に住所を入力していないとその変数を呼び出せないため、
住所入力を必須にした
